### PR TITLE
Adds cloudfront cache invalidation to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ commands:
     parameters:
       environment:
         type: string
+      distrbution_id:
+        type: string
     steps:
       - checkout
       - aws-cli/install
@@ -35,6 +37,9 @@ commands:
       - run:
           name: Sync S3 Bucket
           command: aws s3 sync build/ s3://<< parameters.environment >>-etra-manageatenancy --delete
+      - run:
+          name: Perform Cloud Front invalidation
+          command: aws cloudfront create-invalidation --distribution-id << parameters.distrbution_id >> --paths "/*"
 
 jobs:
   build: 
@@ -64,11 +69,13 @@ jobs:
     steps:
       - deploy-env:
           environment: 'dev'
+          distrbution_id: AWS_CF_DIST_ID_DEV
   deploy-to-staging:
     executor: node
     steps:
       - deploy-env:
           environment: 'staging'
+          distrbution_id: AWS_CF_DIST_ID_STAGING
 workflows:
   version: 2
   build_and_test:


### PR DESCRIPTION
**What**

Runs `aws cloudfront create-invalidation`, because I'm creating different distributions for each environment I've created a new env var in for this project in CircleCI `AWS_CF_DIST_ID_<ENV>` to use the correct Distribution ID to invalidate.