### PR TITLE
Feature: add approval gate to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,10 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-staging-release:
+          type: approval
+          requires:
+            - deploy-to-development
       - deploy-to-staging:
           requires:
             - deploy-to-development


### PR DESCRIPTION
Currently, after a successful merge and tests have been run, the new releases are deployed to both Development and Staging environment as part of the workflow steps.

This will add an additional "approval" step before deploying to Staging.