### PR TITLE
conditionally add prefix to base64 signature

### DIFF
--- a/src/Components/ConfirmationPage/index.tsx
+++ b/src/Components/ConfirmationPage/index.tsx
@@ -68,7 +68,13 @@ export class Confirmation extends React.Component<IConfirmationProps, IConfirmat
   }
 
   private signatureUrl(){
-    return "data:image/png;base64," + this.props.signOff.signature;
+    let signature = "";
+    let prefix = "data:image/png;base64,";
+    if(!this.props.signOff.signature.includes(prefix))
+      signature = "data:image/png;base64," + this.props.signOff.signature;
+    else
+      signature = this.props.signOff.signature;
+    return signature;
   }
 
   private renderSignature(){


### PR DESCRIPTION
What:
- Conditionally add the base 64 prefix for signature

Why:
- Signature in review now flow no longer adds the prefix twice.

Notes:
- MAT-275